### PR TITLE
feat: tag search with index, richer UI filters, and env-based Docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env in this directory and edit before running docker compose.
+# Used by docker-compose.yml (and docker-compose.import.yml when merged).
+
+# Bind published ports to this host IP (Tailscale IP, 127.0.0.1, or 0.0.0.0 for all interfaces).
+BIND_HOST=0.0.0.0
+
+POSTGRES_USER=char_archive
+POSTGRES_PASSWORD=changeme
+POSTGRES_DB=char_archive
+POSTGRES_PORT=5432
+
+PGADMIN_DEFAULT_EMAIL=admin@chararchive.dev
+PGADMIN_DEFAULT_PASSWORD=changeme
+PGADMIN_PORT=5050
+
+FRONTEND_PORT=8080
+
+# Frontend container: archive is mounted at /archive (see volumes in compose).
+IMAGE_LAYOUT=sharded
+IMAGE_SUBDIR=hashed-data
+ENABLE_BROWSE_ALL=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Secrets and local config
+.env
+.env.local
+!.env.example
+small_front/.env
+!small_front/.env.example
+
+# Local dev scripts (copy from *.example.sh)
+small_front/runme.sh
+small_front/rebuild_tags.sh
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# Database and archive data
+db_data/
+*.dump
+archive/
+
+# Docker local overrides
+docker-compose.override.yml
+
+# IDE / OS
+.idea/
+.vscode/
+.DS_Store
+*.swp
+
+# Accidental nested template copy
+small_front/templates/templates/

--- a/README.md
+++ b/README.md
@@ -7,13 +7,18 @@ A Flask-based web application for searching and downloading character cards from
 
 ## Features
 
-- **Full-text search** across all character sources (Chub, JanitorAI, RisuAI, Character Tavern, Booru, Webring, Generic)
-- **Character card previews** with lazy-loaded images
-- **Detailed character modal** showing tags, description, and first message
-- **Card downloads** in PNG format with embedded character data
-- **Source filtering** to search specific platforms
-- **Responsive design** with dark theme and purple gradient accents
-- **Pagination** with customizable results per page
+- **Search** by name, author, and tags across Chub, Generic, Booru, Webring, Character Tavern, RisuAI, and Nyaime
+- **Tag filtering** with autocomplete suggestions, required tags (comma-separated AND), and exclusions (`-tag`); backed by a pre-built `tag_index` for fast lookups
+- **Author filter** plus click-through from result cards and the detail modal to search by author or tag
+- **Sort** by date added or name, ascending or descending
+- **Shareable URLs** — search filters and pagination are reflected in the address bar
+- **Direct character links** at `/character/<source>/<id>` (opens the detail modal)
+- **Character card previews** with lazy-loaded images (flat or sharded archive layouts via env config)
+- **Detail modal** with tags, description, first message, and expandable tag list
+- **Card downloads** as PNG (embedded character data) or raw JSON
+- **Source filtering** per platform; optional **browse-all** mode when `ENABLE_BROWSE_ALL` is enabled
+- **Archive stats** with per-source counts on the home page
+- **Responsive design** with dark theme, purple gradient accents, and customizable results per page
 
 ## Architecture
 
@@ -44,61 +49,39 @@ Single-page application using:
 - Docker Engine (20.10+)
 - Docker Compose (v2.0+)
 - PostgreSQL database with Character Archive data
-- Image archive at `../archive/hashed-data/`
+- Image archive on disk (see [Image storage](#image-storage); Character Archive torrent uses **sharded** layout under `hashed-data/`)
 
 ## Quick Start
 
 ### 1. Set Up Environment Variables
 
-Create a `.env` file or set environment variables:
+From the repository root:
 
 ```bash
-DB_HOST=postgres              # PostgreSQL host
-DB_PORT=5432                  # PostgreSQL port
-DB_NAME=char_archive          # Database name
-DB_USER=char_archive          # Database user
-DB_PASSWORD=your_password     # Database password
-ARCHIVE_PATH=/archive         # Path to archive images
+cp .env.example .env
+# Edit passwords, BIND_HOST (e.g. Tailscale IP), and ports
 ```
+
+Compose mounts `./archive` at `/archive` and sets image path variables for the **sharded** layout by default (`IMAGE_LAYOUT=sharded`, `IMAGE_SUBDIR=hashed-data` in root `.env.example`). Change these if your files use a different layout (see [Image storage](#image-storage)).
 
 ### 2. Run with Docker Compose
 
-Add this service to your `docker-compose.yml`:
-
-```yaml
-services:
-  frontend:
-    build:
-      context: ./small_front
-      dockerfile: Dockerfile
-    environment:
-      DB_HOST: postgres
-      DB_PORT: "5432"
-      DB_NAME: char_archive
-      DB_USER: char_archive
-      DB_PASSWORD: your_password_here
-      ARCHIVE_PATH: /archive
-    volumes:
-      - ./archive:/archive:ro
-    ports:
-      - "8080:5000"
-    depends_on:
-      - postgres
-    networks:
-      - char_archive_network
-```
-
-Start the services:
+First-time import (empty `db_data/postgres`):
 
 ```bash
-docker compose up -d frontend
+docker compose -f docker-compose.yml -f docker-compose.import.yml up -d
+docker compose logs -f postgres   # wait for restore to finish
+```
+
+Normal operation (database already imported):
+
+```bash
+docker compose up -d
 ```
 
 ### 3. Access the Frontend
 
-Open your browser and navigate to:
-- Local: `http://localhost:8080`
-- Tailscale: `http://100.108.69.91:8080` (if configured)
+Open your browser at `http://<BIND_HOST or localhost>:8080` (or the port you set in `FRONTEND_PORT`).
 
 ## Development
 
@@ -115,22 +98,24 @@ cd char-archive-small_frontend/small_front
 pip install -r requirements.txt
 ```
 
-3. Set environment variables:
+3. Configure environment (copy `small_front/.env.example` to `small_front/.env`, or export variables):
 ```bash
 export DB_HOST=localhost
 export DB_PORT=5432
 export DB_NAME=char_archive
 export DB_USER=char_archive
 export DB_PASSWORD=your_password
-export ARCHIVE_PATH=/path/to/archive
+export ARCHIVE_PATH=/path/to/archive          # parent of image files
+export IMAGE_LAYOUT=sharded                   # flat | sharded — see Image storage
+export IMAGE_SUBDIR=hashed-data               # optional subfolder under ARCHIVE_PATH
 ```
 
 4. Run the Flask app:
 ```bash
-python app.py
+./runme.sh
 ```
 
-The app will be available at `http://localhost:5000`
+`runme.sh` loads `.env`, creates/activates the virtualenv if needed, installs dependencies, then starts the app. Default URL: `http://localhost:5000` (set `PORT` in `.env` to change).
 
 ### Rebuild After Changes
 
@@ -218,15 +203,66 @@ Each table follows the pattern:
   - `image_hash`: MD5 hash for image lookup
   - `metadata` (JSON): Safety ratings and token info
 
-## Image Storage
+## Image storage
 
-Images are stored in `archive/hashed-data/` using MD5 hash sharding:
+The frontend resolves files from `image_hash` in the database using three settings (see `small_front/app.py` and `small_front/.env.example`):
 
-**Path format:** `/{h[0]}/{h[1]}/{h[2]}/{h[3:]}`
+| Variable | Role |
+|----------|------|
+| `ARCHIVE_PATH` | Root directory for images (Docker: `/archive` with `./archive` mounted) |
+| `IMAGE_SUBDIR` | Optional folder under `ARCHIVE_PATH` (e.g. `hashed-data`; leave empty if hashes sit directly under the root) |
+| `IMAGE_LAYOUT` | How each hash maps to a path: `flat` or `sharded` |
 
-**Example:**
-- Hash: `54db4830ceab552d4824dd5b016f4b06`
-- Path: `/5/4/d/b4830ceab552d4824dd5b016f4b06`
+Effective lookup root: `ARCHIVE_PATH` / `IMAGE_SUBDIR` (if set).
+
+### Sharded layout (`IMAGE_LAYOUT=sharded`)
+
+Default for Docker Compose and the Character Archive image store. Files are split by the first three hex digits of the MD5 hash.
+
+**Path:** `{root}/{h[0]}/{h[1]}/{h[2]}/{h[3:]}`
+
+**Example** (hash `54db4830ceab552d4824dd5b016f4b06`, `IMAGE_SUBDIR=hashed-data`):
+
+```
+archive/hashed-data/5/4/d/b4830ceab552d4824dd5b016f4b06
+```
+
+**Docker / root `.env`:**
+
+```env
+IMAGE_LAYOUT=sharded
+IMAGE_SUBDIR=hashed-data
+```
+
+### Flat layout (`IMAGE_LAYOUT=flat`)
+
+One file per hash, named with the full hash, directly under the image root (no `h[0]/h[1]/h[2]/` prefix directories).
+
+**Path:** `{root}/{full-hash}`
+
+**Example** (same hash, no subdir):
+
+```
+/mnt/images/54db4830ceab552d4824dd5b016f4b06
+```
+
+**Local dev (`small_front/.env.example` defaults):**
+
+```env
+IMAGE_LAYOUT=flat
+IMAGE_SUBDIR=
+```
+
+Use flat when your archive stores `{ARCHIVE_PATH}/{hash}` files. Use sharded when they live under the hashed directory tree (as in `docs/FILE_STRUCTURE.md`).
+
+### Choosing settings
+
+| Your files on disk | `IMAGE_LAYOUT` | `IMAGE_SUBDIR` |
+|--------------------|----------------|----------------|
+| `archive/hashed-data/5/4/d/...` | `sharded` | `hashed-data` |
+| `archive/5/4/d/...` (no extra folder) | `sharded` | *(empty)* |
+| `archive/<full-md5>` | `flat` | *(empty)* |
+| `archive/cards/<full-md5>` | `flat` | `cards` |
 
 ## Troubleshooting
 
@@ -236,9 +272,10 @@ Images are stored in `archive/hashed-data/` using MD5 hash sharding:
 - Test database directly: `docker compose exec postgres psql -U char_archive -d char_archive`
 
 ### Images not loading
-- Verify archive volume is mounted correctly
-- Check image hash exists in `archive/hashed-data/`
-- Verify file permissions on archive folder
+- Verify archive volume is mounted correctly (`ARCHIVE_PATH` inside the container should match your host tree)
+- Confirm `IMAGE_LAYOUT` and `IMAGE_SUBDIR` match how files are actually stored (wrong layout looks like “missing” images)
+- Check the file exists at the resolved path for a known `image_hash` (sharded vs flat examples above)
+- Verify file permissions on the archive folder
 
 ### Container keeps restarting
 - Check logs: `docker compose logs frontend`
@@ -255,21 +292,33 @@ Images are stored in `archive/hashed-data/` using MD5 hash sharding:
 ```
 char-archive-small_frontend/
 ├── README.md                      # This file
-├── docker-compose.yml             # Production Docker Compose config
-├── docker-compose.import.yml      # Docker Compose with DB import
-├── init-db.sh                     # Database initialization script
-├── docs/                          # Documentation
+├── .env.example                   # Docker Compose env template (copy to .env)
+├── .gitignore
+├── char-archive_final.torrent     # Torrent for full archive + database dump
+├── docker-compose.yml             # Stack: postgres, pgadmin, frontend
+├── docker-compose.import.yml      # DB import overlay (merge with base compose)
+├── init-db.sh                     # Restores database.dump on empty Postgres data dir
+├── database.dump                  # PostgreSQL custom-format dump (local; gitignored; for import)
+├── archive/                       # Image files (local; gitignored — mount into frontend)
+├── db_data/                       # Postgres + pgAdmin persistence (local; gitignored)
+├── docs/
 │   ├── MIGRATION.md               # Server migration guide
 │   ├── setup-guide.md             # Complete Docker setup
 │   ├── frontend-guide.md          # API and architecture details
 │   ├── DATABASE_STRUCTURE.md      # Full database schema
-│   └── FILE_STRUCTURE.md          # Image storage layout
+│   └── FILE_STRUCTURE.md          # Image storage layout (sharded paths)
 └── small_front/                   # Frontend application
+    ├── .env.example               # Local dev env (copy to .env; IMAGE_LAYOUT, etc.)
     ├── app.py                     # Flask API backend
-    ├── templates/
-    │   └── index.html             # Tailwind CSS frontend
+    ├── Dockerfile                 # Container image for Compose frontend service
     ├── requirements.txt           # Python dependencies
-    └── Dockerfile                 # Container configuration
+    ├── rebuild_tag_index.py       # Rebuild tag search index in PostgreSQL
+    ├── rebuild_tags.example.sh    # Example wrapper; copy to rebuild_tags.sh (gitignored)
+    ├── runme.sh                   # Local dev launcher (gitignored; sources .env, runs app.py)
+    ├── sql/
+    │   └── tag_index.sql          # Tag index DDL used by rebuild_tag_index.py
+    └── templates/
+        └── index.html             # Tailwind CSS frontend
 ```
 
 ## Dependencies

--- a/docker-compose.import.yml
+++ b/docker-compose.import.yml
@@ -1,44 +1,14 @@
+# Merge with the base compose file for first-time setup (restores database.dump on empty data dir).
+#
+#   cp .env.example .env && nano .env
+#   docker compose -f docker-compose.yml -f docker-compose.import.yml up -d
+#
+# After import completes, use the base file only:
+#   docker compose up -d
+
 services:
   postgres:
-    image: postgres:16-alpine
-    container_name: char_archive_db
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: char_archive
-      POSTGRES_PASSWORD: CharArch1ve_Db_2026!
-      POSTGRES_DB: char_archive
     volumes:
       - ./db_data/postgres:/var/lib/postgresql/data
       - ./database.dump:/docker-entrypoint-initdb.d/database.dump:ro
       - ./init-db.sh:/docker-entrypoint-initdb.d/zz-init-db.sh:ro
-    ports:
-      - "5432:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U char_archive -d char_archive"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - char_archive_network
-
-  pgadmin:
-    image: dpage/pgadmin4:latest
-    container_name: char_archive_pgadmin
-    restart: unless-stopped
-    environment:
-      PGADMIN_DEFAULT_EMAIL: admin@chararchive.dev
-      PGADMIN_DEFAULT_PASSWORD: PgAdm1n_2026!Secure
-      PGADMIN_CONFIG_SERVER_MODE: "True"
-    volumes:
-      - ./db_data/pgadmin:/var/lib/pgadmin
-    ports:
-      - "5050:80"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    networks:
-      - char_archive_network
-
-networks:
-  char_archive_network:
-    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,37 @@
+# Production stack. Copy .env.example to .env and set BIND_HOST (e.g. Tailscale IP) and passwords.
+# First-time DB import: docker compose -f docker-compose.yml -f docker-compose.import.yml up -d
+
+x-postgres-env: &postgres-env
+  POSTGRES_USER: ${POSTGRES_USER:-char_archive}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+  POSTGRES_DB: ${POSTGRES_DB:-char_archive}
+
+x-frontend-env: &frontend-env
+  DB_HOST: postgres
+  DB_PORT: "5432"
+  DB_NAME: ${POSTGRES_DB:-char_archive}
+  DB_USER: ${POSTGRES_USER:-char_archive}
+  DB_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+  ARCHIVE_PATH: /archive
+  IMAGE_LAYOUT: ${IMAGE_LAYOUT:-sharded}
+  IMAGE_SUBDIR: ${IMAGE_SUBDIR:-hashed-data}
+  ENABLE_BROWSE_ALL: ${ENABLE_BROWSE_ALL:-false}
+
 services:
   postgres:
     image: postgres:16-alpine
     container_name: char_archive_db
     restart: unless-stopped
     environment:
-      POSTGRES_USER: char_archive
-      POSTGRES_PASSWORD: CharArch1ve_Db_2026!
-      POSTGRES_DB: char_archive
+      <<: *postgres-env
     volumes:
       - ./db_data/postgres:/var/lib/postgresql/data
     ports:
-      - "100.108.69.91:5432:5432"
+      - target: 5432
+        published: ${POSTGRES_PORT:-5432}
+        host_ip: ${BIND_HOST:-0.0.0.0}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U char_archive -d char_archive"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-char_archive} -d ${POSTGRES_DB:-char_archive}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -24,13 +43,15 @@ services:
     container_name: char_archive_pgadmin
     restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@chararchive.dev
-      PGADMIN_DEFAULT_PASSWORD: PgAdm1n_2026!Secure
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@chararchive.dev}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:?Set PGADMIN_DEFAULT_PASSWORD in .env}
       PGADMIN_CONFIG_SERVER_MODE: "True"
     volumes:
       - ./db_data/pgadmin:/var/lib/pgadmin
     ports:
-      - "100.108.69.91:5050:80"
+      - target: 80
+        published: ${PGADMIN_PORT:-5050}
+        host_ip: ${BIND_HOST:-0.0.0.0}
     depends_on:
       postgres:
         condition: service_healthy
@@ -44,19 +65,22 @@ services:
     container_name: char_archive_frontend
     restart: unless-stopped
     environment:
-      DB_HOST: postgres
-      DB_PORT: "5432"
-      DB_NAME: char_archive
-      DB_USER: char_archive
-      DB_PASSWORD: CharArch1ve_Db_2026!
-      ARCHIVE_PATH: /archive
+      <<: *frontend-env
     volumes:
       - ./archive:/archive:ro
     ports:
-      - "100.108.69.91:8080:5000"
+      - target: 5000
+        published: ${FRONTEND_PORT:-8080}
+        host_ip: ${BIND_HOST:-0.0.0.0}
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:5000/api/stats')\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     networks:
       - char_archive_network
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -72,32 +72,25 @@ tar -xvzf ../char-archive-backup.tar.gz
 
 ### Step 3: Update Configuration
 
-Edit `docker-compose.yml` on the new server:
+Copy and edit `.env` on the new server:
 
 ```bash
-nano docker-compose.yml
+cp .env.example .env
+nano .env
 ```
 
-**Update the IP addresses** from `100.108.69.91` to your new server's IP:
+Set `BIND_HOST` to your server or Tailscale IP (or `0.0.0.0` / `127.0.0.1` as needed). Ports are controlled with `POSTGRES_PORT`, `PGADMIN_PORT`, and `FRONTEND_PORT`:
 
-```yaml
-ports:
-  - "YOUR_NEW_IP:5432:5432"   # PostgreSQL
-  - "YOUR_NEW_IP:5050:80"     # pgAdmin
-  - "YOUR_NEW_IP:8080:5000"   # Frontend
+```env
+BIND_HOST=YOUR_NEW_IP
+POSTGRES_PORT=5432
+PGADMIN_PORT=5050
+FRONTEND_PORT=8080
 ```
 
-Or use `0.0.0.0` to listen on all interfaces:
-```yaml
-ports:
-  - "5432:5432"
-  - "5050:80"
-  - "8080:5000"
-```
+Or set `BIND_HOST=0.0.0.0` to listen on all interfaces.
 
-**Optionally update passwords** in:
-- `docker-compose.yml` (environment variables)
-- `database_logins.md` (documentation)
+**Update passwords** in `.env` and `database_logins.md` (documentation).
 
 ### Step 4: Create Data Directories
 
@@ -107,20 +100,14 @@ mkdir -p db_data/postgres db_data/pgadmin
 
 ### Step 5: Import the Database
 
-**Option A: Using the import compose file**
+**Option A: Using the import compose overlay**
 
-If you have `docs/docker-compose.yml.backup`:
 ```bash
-cp docs/docker-compose.yml.backup docker-compose.yml.import
+cp .env.example .env
+nano .env   # set BIND_HOST, passwords
 
-# Edit to update IP addresses
-nano docker-compose.yml.import
-
-# Start with import configuration
-docker compose -f docker-compose.yml.import up -d
-
-# Watch import progress
-docker compose -f docker-compose.yml.import logs -f postgres
+docker compose -f docker-compose.yml -f docker-compose.import.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.import.yml logs -f postgres
 ```
 
 **Option B: Manual import**

--- a/docs/frontend-guide.md
+++ b/docs/frontend-guide.md
@@ -133,25 +133,7 @@ Images are stored in `archive/hashed-data/` using MD5 hash sharding:
 
 ## Docker Configuration
 
-The frontend runs as a Docker container:
-
-```yaml
-frontend:
-  build:
-    context: ./small_front
-    dockerfile: Dockerfile
-  environment:
-    DB_HOST: postgres
-    DB_PORT: "5432"
-    DB_NAME: char_archive
-    DB_USER: char_archive
-    DB_PASSWORD: <password>
-    ARCHIVE_PATH: /archive
-  volumes:
-    - ./archive:/archive:ro
-  ports:
-    - "100.108.69.91:8080:5000"
-```
+The frontend is defined in `docker-compose.yml` (build context `./small_front`). Credentials and bind addresses come from the root `.env` file (see `.env.example`). Image paths use `IMAGE_LAYOUT=sharded` and `IMAGE_SUBDIR=hashed-data` so files under `archive/hashed-data/` resolve correctly inside the container.
 
 ## Development
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -112,29 +112,20 @@ docker compose up -d
 
 ## Database Import (Manual)
 
-The database has already been imported from `database.dump`. If you need to re-import or import on a fresh setup, use the backup compose file which includes auto-import functionality.
+The database has already been imported from `database.dump`. If you need to re-import or import on a fresh setup, merge `docker-compose.import.yml` (mounts `database.dump` and `init-db.sh`).
 
-### Using the Backup Compose File (with auto-import)
+### Fresh import (auto-restore)
 
-A backup of the docker-compose.yml with database import capability is stored at `docs/docker-compose.yml.backup`. This version includes:
-- Mounting of `database.dump` file
-- Mounting of `init-db.sh` script for automatic restoration
-
-To use it for a fresh import:
 ```bash
+cp .env.example .env   # edit passwords and BIND_HOST
 docker compose down
 sudo rm -rf db_data/postgres db_data/pgadmin
 mkdir -p db_data/postgres db_data/pgadmin
-cp docs/docker-compose.yml.backup docker-compose.yml
-docker compose up -d
-docker compose logs -f postgres  # Watch import progress
+docker compose -f docker-compose.yml -f docker-compose.import.yml up -d
+docker compose logs -f postgres   # watch import progress
 ```
 
-After import completes, restore the production compose file:
-```bash
-# Copy current (production) compose back
-# Or simply remove the import volume mounts manually
-```
+After import completes, use the base file only: `docker compose up -d`.
 
 ### Manual Import with pg_restore
 

--- a/small_front/.env.example
+++ b/small_front/.env.example
@@ -1,0 +1,24 @@
+# Copy to .env in this directory and edit before running ./runme.sh or ./rebuild_tags.sh.
+
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=char_archive
+DB_USER=char_archive
+DB_PASSWORD=changeme
+
+# Path to the image archive on your machine
+ARCHIVE_PATH=/path/to/images
+
+# flat = ARCHIVE_PATH/<hash>  |  sharded = ARCHIVE_PATH/<h0>/<h1>/<h2>/<rest>
+IMAGE_LAYOUT=flat
+# Optional subfolder under ARCHIVE_PATH (e.g. hashed-data)
+IMAGE_SUBDIR=
+
+# Set true to let users click the stats line to browse the full archive. 
+#Do not enable unless your server can handle this.
+ENABLE_BROWSE_ALL=false
+
+PORT=5000
+
+# Python virtualenv used by runme.sh / rebuild_tags.sh
+VENV_PATH=~/venv

--- a/small_front/app.py
+++ b/small_front/app.py
@@ -13,9 +13,179 @@ DB_HOST = os.environ.get('DB_HOST', 'postgres')
 DB_PORT = os.environ.get('DB_PORT', '5432')
 DB_NAME = os.environ.get('DB_NAME', 'char_archive')
 DB_USER = os.environ.get('DB_USER', 'char_archive')
-DB_PASSWORD = os.environ.get('DB_PASSWORD', 'CharArch1ve_Db_2026!')
+DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
 ARCHIVE_PATH = Path(os.environ.get('ARCHIVE_PATH', '/archive'))
-HASHED_DATA_PATH = ARCHIVE_PATH / 'hashed-data'
+# IMAGE_SUBDIR: optional folder under ARCHIVE_PATH (e.g. hashed-data)
+IMAGE_SUBDIR = os.environ.get('IMAGE_SUBDIR', '').strip().strip('/')
+# IMAGE_LAYOUT: flat = root/<full-hash>  |  sharded = root/<h0>/<h1>/<h2>/<rest>
+IMAGE_LAYOUT = os.environ.get('IMAGE_LAYOUT', 'flat').lower()
+
+
+def image_root():
+    return ARCHIVE_PATH / IMAGE_SUBDIR if IMAGE_SUBDIR else ARCHIVE_PATH
+
+
+def get_image_path(image_hash):
+    """Convert image hash to file path based on IMAGE_LAYOUT."""
+    if not image_hash or len(image_hash) < 4:
+        return None
+    h = image_hash.lower()
+    root = image_root()
+    if IMAGE_LAYOUT == 'sharded':
+        return root / h[0] / h[1] / h[2] / h[3:]
+    if IMAGE_LAYOUT == 'flat':
+        return root / h
+    return None
+
+
+def browse_all_enabled():
+    return os.environ.get('ENABLE_BROWSE_ALL', 'false').lower() in ('1', 'true', 'yes')
+
+
+SORT_COLUMNS = {'added': 'added', 'name': 'name'}
+
+SOURCE_CONFIG = {
+    'chub': {
+        'label': 'Chub',
+        'table': 'chub_character_def',
+        'id_col': 'id',
+        'name_col': 'name',
+        'download_name_col': 'name',
+        'has_author': True,
+        'columns': "id::text, author, name, image_hash, added, 'chub' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
+    },
+    'generic': {
+        'label': 'Generic',
+        'table': 'generic_character_def',
+        'id_col': 'card_data_hash',
+        'name_col': 'name',
+        'download_name_col': 'name',
+        'has_author': False,
+        'columns': "card_data_hash as id, '' as author, name, image_hash, added, 'generic' as source, COALESCE(LEFT(definition->'data'->>'description', 150), COALESCE(LEFT(tagline, 150), '')) as tagline",
+    },
+    'booru': {
+        'label': 'Booru',
+        'table': 'booru_character_def',
+        'id_col': 'id',
+        'name_col': 'name',
+        'download_name_col': 'name',
+        'has_author': True,
+        'columns': "id::text, author, name, image_hash, added, 'booru' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
+    },
+    'webring': {
+        'label': 'Webring',
+        'table': 'webring_character_def',
+        'id_col': 'card_data_hash',
+        'name_col': 'name',
+        'download_name_col': 'name',
+        'has_author': True,
+        'columns': "card_data_hash as id, author, name, image_hash, added, 'webring' as source, COALESCE(LEFT(definition->'data'->>'description', 150), COALESCE(LEFT(tagline, 150), '')) as tagline",
+    },
+    'char_tavern': {
+        'label': 'Character Tavern',
+        'table': 'char_tavern_character_def',
+        'id_col': 'path',
+        'name_col': 'path',
+        'download_name_col': 'path',
+        'has_author': False,
+        'columns': "path as id, '' as author, path as name, image_hash, added, 'char_tavern' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
+    },
+    'risuai': {
+        'label': 'RisuAI',
+        'table': 'risuai_character_def',
+        'id_col': 'id',
+        'name_col': 'author',
+        'download_name_col': 'id',
+        'has_author': True,
+        'columns': "id::text, author, author as name, image_hash, added, 'risuai' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
+    },
+    'nyaime': {
+        'label': 'Nyaime',
+        'table': 'nyaime_character_def',
+        'id_col': 'id',
+        'name_col': 'author',
+        'download_name_col': 'id',
+        'has_author': True,
+        'columns': "id::text, author, author as name, image_hash, added, 'nyaime' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
+    },
+}
+
+TAG_EXISTS_SQL = """
+EXISTS (
+    SELECT 1 FROM jsonb_array_elements_text(
+        COALESCE(definition->'data'->'tags', definition->'tags', '[]'::jsonb)
+    ) AS t(tag)
+    WHERE lower(t.tag) = lower(%s)
+)
+"""
+
+TAG_NOT_EXISTS_SQL = """
+NOT EXISTS (
+    SELECT 1 FROM jsonb_array_elements_text(
+        COALESCE(definition->'data'->'tags', definition->'tags', '[]'::jsonb)
+    ) AS t(tag)
+    WHERE lower(t.tag) = lower(%s)
+)
+"""
+
+
+def parse_tag_filters(tag_tokens):
+    """Split comma-separated tags into required (AND) and excluded (-tag) lists."""
+    include = []
+    exclude = []
+    for token in tag_tokens:
+        if token.startswith('-') and len(token) > 1:
+            exclude.append(token[1:].strip())
+        elif not token.startswith('-'):
+            include.append(token)
+    return include, exclude
+
+
+_available_sources = None
+
+
+def get_available_sources():
+    """Load sources from SOURCE_CONFIG whose tables exist in the database."""
+    global _available_sources
+    if _available_sources is not None:
+        return _available_sources
+
+    sources = []
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        for source_id, cfg in SOURCE_CONFIG.items():
+            cur.execute(
+                """
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.tables
+                    WHERE table_schema = 'public' AND table_name = %s
+                ) AS ok
+                """,
+                (cfg['table'],),
+            )
+            if cur.fetchone()['ok']:
+                sources.append({
+                    'id': source_id,
+                    'label': cfg.get('label', source_id.replace('_', ' ').title()),
+                    'table': cfg['table'],
+                })
+        cur.close()
+        conn.close()
+    except Exception as e:
+        print(f"Source discovery error: {e}")
+        sources = [
+            {
+                'id': source_id,
+                'label': cfg.get('label', source_id.replace('_', ' ').title()),
+                'table': cfg['table'],
+            }
+            for source_id, cfg in SOURCE_CONFIG.items()
+        ]
+
+    _available_sources = sources
+    return _available_sources
+
 
 def get_db_connection():
     return psycopg2.connect(
@@ -27,123 +197,235 @@ def get_db_connection():
         cursor_factory=RealDictCursor
     )
 
-def get_image_path(image_hash):
-    """Convert image hash to file path."""
-    if not image_hash or len(image_hash) < 4:
-        return None
-    h = image_hash.lower()
-    return HASHED_DATA_PATH / h[0] / h[1] / h[2] / h[3:]
 
-@app.route('/')
-def index():
-    return render_template('index.html')
+def get_source_config(source):
+    available = {s['id']: SOURCE_CONFIG[s['id']] for s in get_available_sources()}
+    if source == 'all':
+        return available
+    if source in available:
+        return {source: available[source]}
+    return {}
 
-@app.route('/api/search')
-def search():
+
+def build_source_subquery(src_name, src_info, name, author, include_tags, exclude_tags, use_tag_index):
+    """Build one UNION ALL branch with filters applied."""
+    if author and not src_info['has_author']:
+        return None, []
+
+    where_parts = []
+    params = []
+    table = src_info['table']
+    id_col = src_info['id_col']
+
+    if name:
+        where_parts.append(f"{src_info['name_col']} ILIKE %s")
+        params.append(f'%{name}%')
+
+    if author:
+        where_parts.append('author ILIKE %s')
+        params.append(f'%{author}%')
+
+    for tag in include_tags:
+        if use_tag_index:
+            where_parts.append(f"""
+                EXISTS (
+                    SELECT 1 FROM character_tags ct
+                    WHERE ct.source = %s
+                      AND ct.char_key = {table}.{id_col}::text
+                      AND ct.tag_norm = lower(%s)
+                )
+            """)
+            params.extend([src_name, tag])
+        else:
+            where_parts.append(TAG_EXISTS_SQL)
+            params.append(tag)
+
+    for tag in exclude_tags:
+        if use_tag_index:
+            where_parts.append(f"""
+                NOT EXISTS (
+                    SELECT 1 FROM character_tags ct
+                    WHERE ct.source = %s
+                      AND ct.char_key = {table}.{id_col}::text
+                      AND ct.tag_norm = lower(%s)
+                )
+            """)
+            params.extend([src_name, tag])
+        else:
+            where_parts.append(TAG_NOT_EXISTS_SQL)
+            params.append(tag)
+
+    if not where_parts:
+        where_parts.append('TRUE')
+
+    where_clause = ' AND '.join(where_parts)
+    query = f"""
+        SELECT {src_info['columns']}
+        FROM {table}
+        WHERE {where_clause}
+    """
+    return query, params
+
+
+def tag_index_populated(cur):
+    cur.execute('SELECT EXISTS (SELECT 1 FROM tag_index LIMIT 1) AS ok')
+    return cur.fetchone()['ok']
+
+
+@app.route('/api/tags')
+def tag_suggestions():
+    """Return tag suggestions from pre-built tag_index (fast prefix search)."""
     query = request.args.get('q', '').strip()
     source = request.args.get('source', 'all')
-    page = int(request.args.get('page', 1))
-    per_page = int(request.args.get('per_page', 24))
-    offset = (page - 1) * per_page
+    limit = min(max(int(request.args.get('limit', 25)), 1), 50)
 
-    if not query:
-        return jsonify({'results': [], 'total': 0, 'page': page})
-
-    results = []
-    total = 0
+    if len(query) < 2:
+        return jsonify({'tags': []})
 
     try:
         conn = get_db_connection()
         cur = conn.cursor()
 
-        # Search pattern
-        search_pattern = f'%{query}%'
+        if not tag_index_populated(cur):
+            cur.close()
+            conn.close()
+            return jsonify({
+                'tags': [],
+                'warning': 'Tag index empty. Run: python rebuild_tag_index.py'
+            })
 
-        # Define source tables with their search configurations
-        # Each source specifies columns to select and which columns to search
-        sources = {
-            'chub': {
-                'table': 'chub_character_def',
-                'columns': "id::text, author, name, image_hash, added, 'chub' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
-                'search_cols': ['name', 'author']
-            },
-            'generic': {
-                'table': 'generic_character_def',
-                'columns': "card_data_hash as id, '' as author, name, image_hash, added, 'generic' as source, COALESCE(LEFT(definition->'data'->>'description', 150), COALESCE(LEFT(tagline, 150), '')) as tagline",
-                'search_cols': ['name']
-            },
-            'booru': {
-                'table': 'booru_character_def',
-                'columns': "id::text, author, name, image_hash, added, 'booru' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
-                'search_cols': ['name', 'author']
-            },
-            'webring': {
-                'table': 'webring_character_def',
-                'columns': "card_data_hash as id, author, name, image_hash, added, 'webring' as source, COALESCE(LEFT(definition->'data'->>'description', 150), COALESCE(LEFT(tagline, 150), '')) as tagline",
-                'search_cols': ['name', 'author']
-            },
-            'char_tavern': {
-                'table': 'char_tavern_character_def',
-                'columns': "path as id, '' as author, path as name, image_hash, added, 'char_tavern' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
-                'search_cols': ['path']
-            },
-            'risuai': {
-                'table': 'risuai_character_def',
-                'columns': "id::text, author, author as name, image_hash, added, 'risuai' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
-                'search_cols': ['author']
-            },
-            'nyaime': {
-                'table': 'nyaime_character_def',
-                'columns': "id::text, author, author as name, image_hash, added, 'nyaime' as source, COALESCE(LEFT(definition->'data'->>'description', 150), '') as tagline",
-                'search_cols': ['author']
-            }
-        }
+        prefix = query.lower()
+        if source == 'all':
+            sql = """
+                SELECT
+                    (array_agg(tag ORDER BY count DESC))[1] AS tag,
+                    SUM(count) AS count
+                FROM tag_index
+                WHERE tag_norm LIKE %s
+                GROUP BY tag_norm
+                ORDER BY count DESC, tag ASC
+                LIMIT %s
+            """
+            cur.execute(sql, (f'{prefix}%', limit))
+        else:
+            if source not in SOURCE_CONFIG:
+                return jsonify({'tags': []})
+            sql = """
+                SELECT tag, count
+                FROM tag_index
+                WHERE source = %s AND tag_norm LIKE %s
+                ORDER BY count DESC, tag ASC
+                LIMIT %s
+            """
+            cur.execute(sql, (source, f'{prefix}%', limit))
 
-        if source != 'all':
-            sources = {source: sources[source]} if source in sources else {}
+        tags = [{'tag': row['tag'], 'count': row['count']} for row in cur.fetchall()]
+        cur.close()
+        conn.close()
+        return jsonify({'tags': tags})
 
-        # Build union query for searching across tables
+    except Exception as e:
+        print(f"Tag suggestion error: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.context_processor
+def inject_template_config():
+    return {
+        'browse_all_enabled': browse_all_enabled(),
+        'sources': get_available_sources(),
+    }
+
+
+@app.route('/')
+def index():
+    return render_template('index.html', open_character=None)
+
+
+@app.route('/character/<source>/<path:char_id>')
+def character_page(source, char_id):
+    if source not in SOURCE_CONFIG:
+        abort(404)
+    return render_template('index.html', open_character={'source': source, 'id': char_id})
+
+
+@app.route('/api/search')
+def search():
+    name = request.args.get('name', '').strip()
+    author = request.args.get('author', '').strip()
+    tag_tokens = [t.strip() for t in request.args.get('tags', '').split(',') if t.strip()]
+    include_tags, exclude_tags = parse_tag_filters(tag_tokens)
+    source = request.args.get('source', 'all')
+    page = max(int(request.args.get('page', 1)), 1)
+    per_page = max(int(request.args.get('per_page', 24)), 1)
+    offset = (page - 1) * per_page
+
+    browse_all = (
+        browse_all_enabled()
+        and request.args.get('browse', '').lower() == 'all'
+    )
+    has_filters = browse_all or bool(name or author or tag_tokens or source != 'all')
+    if not has_filters:
+        return jsonify({'results': [], 'total': 0, 'page': page, 'per_page': per_page, 'pages': 0})
+
+    sort_key = request.args.get('sort', 'added')
+    sort_col = SORT_COLUMNS.get(sort_key, 'added')
+    order = 'ASC' if request.args.get('order', 'desc').lower() == 'asc' else 'DESC'
+
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+
         union_parts = []
         params = []
+        use_tag_index = tag_index_populated(cur)
 
-        for src_name, src_info in sources.items():
-            # Build WHERE clause based on searchable columns for this table
-            where_conditions = ' OR '.join([f"{col} ILIKE %s" for col in src_info['search_cols']])
-            union_parts.append(f"""
-                SELECT {src_info['columns']}
-                FROM {src_info['table']}
-                WHERE {where_conditions}
-            """)
-            params.extend([search_pattern] * len(src_info['search_cols']))
+        for src_name, src_info in get_source_config(source).items():
+            subquery, sub_params = build_source_subquery(
+                src_name, src_info, name, author, include_tags, exclude_tags, use_tag_index
+            )
+            if subquery:
+                union_parts.append(subquery)
+                params.extend(sub_params)
 
         if not union_parts:
-            return jsonify({'results': [], 'total': 0, 'page': page})
+            return jsonify({'results': [], 'total': 0, 'page': page, 'per_page': per_page, 'pages': 0})
 
-        # Count total results
-        count_query = f"""
-            SELECT COUNT(*) as total FROM (
-                {' UNION ALL '.join(union_parts)}
-            ) combined
-        """
-        cur.execute(count_query, params)
-        total = cur.fetchone()['total']
-
-        # Get paginated results
+        combined = ' UNION ALL '.join(union_parts)
+        # 1) One row per source+id (latest version). 2) Collapse same author/name/date.
         results_query = f"""
-            SELECT * FROM (
-                {' UNION ALL '.join(union_parts)}
-            ) combined
-            ORDER BY added DESC
+            WITH combined AS (
+                {combined}
+            ),
+            by_id AS (
+                SELECT DISTINCT ON (source, id)
+                    id, author, name, image_hash, added, source, tagline
+                FROM combined
+                ORDER BY source, id, added DESC
+            ),
+            deduped AS (
+                SELECT DISTINCT ON (source, COALESCE(author, ''), name, added::date)
+                    id, author, name, image_hash, added, source, tagline
+                FROM by_id
+                ORDER BY source, COALESCE(author, ''), name, added::date, added DESC, id
+            )
+            SELECT *, COUNT(*) OVER() AS total_count
+            FROM deduped
+            ORDER BY {sort_col} {order}
             LIMIT %s OFFSET %s
         """
         cur.execute(results_query, params + [per_page, offset])
-        results = cur.fetchall()
+        rows = cur.fetchall()
+
+        total = rows[0]['total_count'] if rows else 0
+        results = []
+        for row in rows:
+            item = dict(row)
+            del item['total_count']
+            results.append(item)
 
         cur.close()
         conn.close()
-
-        # Convert to list of dicts
-        results = [dict(r) for r in results]
 
     except Exception as e:
         print(f"Database error: {e}")
@@ -154,34 +436,27 @@ def search():
         'total': total,
         'page': page,
         'per_page': per_page,
-        'pages': (total + per_page - 1) // per_page
+        'pages': (total + per_page - 1) // per_page if total else 0
     })
+
 
 @app.route('/api/character/<source>/<path:char_id>')
 def get_character(source, char_id):
     """Get detailed character information."""
+    if source not in SOURCE_CONFIG:
+        return jsonify({'error': 'Invalid source'}), 400
+
     try:
         conn = get_db_connection()
         cur = conn.cursor()
 
-        table_map = {
-            'chub': ('chub_character_def', 'id', 'id = %s'),
-            'generic': ('generic_character_def', 'card_data_hash', 'card_data_hash = %s'),
-            'booru': ('booru_character_def', 'id', 'id = %s'),
-            'webring': ('webring_character_def', 'card_data_hash', 'card_data_hash = %s'),
-            'char_tavern': ('char_tavern_character_def', 'path', 'path = %s'),
-            'risuai': ('risuai_character_def', 'id', 'id = %s'),
-            'nyaime': ('nyaime_character_def', 'id', 'id = %s')
-        }
-
-        if source not in table_map:
-            return jsonify({'error': 'Invalid source'}), 400
-
-        table, id_col, where = table_map[source]
+        cfg = SOURCE_CONFIG[source]
+        table = cfg['table']
+        id_col = cfg['id_col']
 
         cur.execute(f"""
             SELECT * FROM {table}
-            WHERE {where}
+            WHERE {id_col} = %s
             ORDER BY added DESC
             LIMIT 1
         """, (char_id,))
@@ -193,10 +468,7 @@ def get_character(source, char_id):
         if not result:
             return jsonify({'error': 'Character not found'}), 404
 
-        # Convert to dict and handle special fields
         char_data = dict(result)
-
-        # Remove raw bytes from response (too large)
         if 'raw' in char_data:
             char_data['has_raw'] = True
             del char_data['raw']
@@ -207,65 +479,46 @@ def get_character(source, char_id):
         print(f"Database error: {e}")
         return jsonify({'error': str(e)}), 500
 
+
 def embed_chara_in_png(png_data, chara_json):
     """Embed character data into PNG as a tEXt chunk with keyword 'chara'."""
     import struct
     import base64
     import zlib as zlib_mod
 
-    # Base64 encode the character JSON
     chara_b64 = base64.b64encode(chara_json.encode('utf-8'))
-
-    # Create tEXt chunk: keyword + null separator + text
     keyword = b'chara'
     text_data = keyword + b'\x00' + chara_b64
-
-    # Calculate CRC for the chunk (includes type + data)
     chunk_type = b'tEXt'
     crc = zlib_mod.crc32(chunk_type + text_data) & 0xffffffff
-
-    # Build the chunk: length (4 bytes) + type (4 bytes) + data + crc (4 bytes)
     chunk = struct.pack('>I', len(text_data)) + chunk_type + text_data + struct.pack('>I', crc)
 
-    # Find the position to insert (before IEND chunk)
-    # IEND is the last 12 bytes: length(4) + 'IEND'(4) + crc(4)
     iend_pos = png_data.rfind(b'IEND')
     if iend_pos == -1:
         raise ValueError("Invalid PNG: no IEND chunk found")
 
-    # IEND chunk starts 4 bytes before 'IEND' (the length field)
     insert_pos = iend_pos - 4
+    return png_data[:insert_pos] + chunk + png_data[insert_pos:]
 
-    # Insert our tEXt chunk before IEND
-    new_png = png_data[:insert_pos] + chunk + png_data[insert_pos:]
-
-    return new_png
 
 @app.route('/api/card/<source>/<path:char_id>')
 def download_card(source, char_id):
     """Download character as PNG card with embedded data."""
+    if source not in SOURCE_CONFIG:
+        return jsonify({'error': 'Invalid source'}), 400
+
     try:
         conn = get_db_connection()
         cur = conn.cursor()
 
-        table_map = {
-            'chub': ('chub_character_def', 'id = %s', 'name'),
-            'generic': ('generic_character_def', 'card_data_hash = %s', 'name'),
-            'booru': ('booru_character_def', 'id = %s', 'name'),
-            'webring': ('webring_character_def', 'card_data_hash = %s', 'name'),
-            'char_tavern': ('char_tavern_character_def', 'path = %s', 'path'),
-            'risuai': ('risuai_character_def', 'id = %s', 'id'),
-            'nyaime': ('nyaime_character_def', 'id = %s', 'id')
-        }
-
-        if source not in table_map:
-            return jsonify({'error': 'Invalid source'}), 400
-
-        table, where, name_col = table_map[source]
+        cfg = SOURCE_CONFIG[source]
+        table = cfg['table']
+        id_col = cfg['id_col']
+        name_col = cfg['download_name_col']
 
         cur.execute(f"""
             SELECT {name_col}, raw, image_hash, definition FROM {table}
-            WHERE {where}
+            WHERE {id_col} = %s
             ORDER BY added DESC
             LIMIT 1
         """, (char_id,))
@@ -285,20 +538,15 @@ def download_card(source, char_id):
         image_hash = result['image_hash']
         definition = result['definition']
         name = result[name_col] or char_id
-
-        # Sanitize filename
         safe_name = "".join(c for c in str(name) if c.isalnum() or c in ' -_').strip() or 'character'
 
-        # Decompress raw if needed
         if raw_data:
             try:
                 raw_data = zlib.decompress(raw_data)
-            except:
+            except Exception:
                 pass
 
-        # Check if raw_data is already a valid PNG with embedded data
         if raw_data and raw_data[:8] == b'\x89PNG\r\n\x1a\n':
-            # It's already a PNG, return as-is
             return send_file(
                 io.BytesIO(raw_data),
                 mimetype='image/png',
@@ -306,34 +554,26 @@ def download_card(source, char_id):
                 download_name=f"{safe_name}.png"
             )
 
-        # Otherwise, we need to create a PNG card by embedding the definition into the image
-        # Get the image file
         image_path = get_image_path(image_hash)
         if not image_path or not image_path.exists():
             return jsonify({'error': 'Image not found'}), 404
 
-        # Read the original image
         with open(image_path, 'rb') as f:
             png_data = f.read()
 
-        # Verify it's a PNG
         if png_data[:8] != b'\x89PNG\r\n\x1a\n':
             return jsonify({'error': 'Image is not a valid PNG'}), 500
 
-        # Get character JSON - prefer raw (decompressed) if it's JSON, otherwise use definition
         if raw_data:
             try:
-                # Check if raw_data is valid JSON
                 json.loads(raw_data.decode('utf-8'))
                 chara_json = raw_data.decode('utf-8')
-            except:
+            except Exception:
                 chara_json = json.dumps(definition, ensure_ascii=False)
         else:
             chara_json = json.dumps(definition, ensure_ascii=False)
 
-        # Embed the character data into the PNG
         card_png = embed_chara_in_png(png_data, chara_json)
-
         return send_file(
             io.BytesIO(card_png),
             mimetype='image/png',
@@ -347,31 +587,25 @@ def download_card(source, char_id):
         traceback.print_exc()
         return jsonify({'error': str(e)}), 500
 
+
 @app.route('/api/card/<source>/<path:char_id>/json')
 def download_card_json(source, char_id):
     """Download character definition as JSON."""
+    if source not in SOURCE_CONFIG:
+        return jsonify({'error': 'Invalid source'}), 400
+
     try:
         conn = get_db_connection()
         cur = conn.cursor()
 
-        table_map = {
-            'chub': ('chub_character_def', 'id = %s', 'name'),
-            'generic': ('generic_character_def', 'card_data_hash = %s', 'name'),
-            'booru': ('booru_character_def', 'id = %s', 'name'),
-            'webring': ('webring_character_def', 'card_data_hash = %s', 'name'),
-            'char_tavern': ('char_tavern_character_def', 'path = %s', 'path'),
-            'risuai': ('risuai_character_def', 'id = %s', 'id'),
-            'nyaime': ('nyaime_character_def', 'id = %s', 'id')
-        }
-
-        if source not in table_map:
-            return jsonify({'error': 'Invalid source'}), 400
-
-        table, where, name_col = table_map[source]
+        cfg = SOURCE_CONFIG[source]
+        table = cfg['table']
+        id_col = cfg['id_col']
+        name_col = cfg['download_name_col']
 
         cur.execute(f"""
             SELECT {name_col}, definition FROM {table}
-            WHERE {where}
+            WHERE {id_col} = %s
             ORDER BY added DESC
             LIMIT 1
         """, (char_id,))
@@ -388,11 +622,7 @@ def download_card_json(source, char_id):
 
         name = result[name_col] or char_id
         definition = result['definition']
-
-        # Sanitize filename
         safe_name = "".join(c for c in str(name) if c.isalnum() or c in ' -_').strip() or 'character'
-
-        # Convert definition to JSON string
         json_data = json.dumps(definition, indent=2, ensure_ascii=False)
 
         return send_file(
@@ -406,15 +636,15 @@ def download_card_json(source, char_id):
         print(f"JSON download error: {e}")
         return jsonify({'error': str(e)}), 500
 
+
 @app.route('/image/<image_hash>')
 def serve_image(image_hash):
     """Serve character image by hash."""
     image_path = get_image_path(image_hash)
-
     if not image_path or not image_path.exists():
         abort(404)
-
     return send_file(image_path, mimetype='image/png')
+
 
 @app.route('/api/stats')
 def stats():
@@ -423,34 +653,25 @@ def stats():
         conn = get_db_connection()
         cur = conn.cursor()
 
-        stats = {}
-        tables = [
-            ('chub', 'chub_character_def'),
-            ('generic', 'generic_character_def'),
-            ('booru', 'booru_character_def'),
-            ('webring', 'webring_character_def'),
-            ('char_tavern', 'char_tavern_character_def'),
-            ('risuai', 'risuai_character_def'),
-            ('nyaime', 'nyaime_character_def')
-        ]
-
+        stats_data = {}
         total = 0
-        for name, table in tables:
-            cur.execute(f"SELECT COUNT(*) as count FROM {table}")
+        for src in get_available_sources():
+            cur.execute(f"SELECT COUNT(*) as count FROM {src['table']}")
             count = cur.fetchone()['count']
-            stats[name] = count
+            stats_data[src['id']] = count
             total += count
 
-        stats['total'] = total
-
+        stats_data['total'] = total
         cur.close()
         conn.close()
-
-        return jsonify(stats)
+        return jsonify(stats_data)
 
     except Exception as e:
         print(f"Stats error: {e}")
         return jsonify({'error': str(e)}), 500
 
+
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    get_available_sources()
+    port = int(os.environ.get('PORT', 5001))
+    app.run(host='0.0.0.0', port=port, debug=True)

--- a/small_front/rebuild_tag_index.py
+++ b/small_front/rebuild_tag_index.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Create tag index schema and rebuild from latest character definitions."""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import psycopg2
+
+DB_HOST = os.environ.get('DB_HOST', 'postgres')
+DB_PORT = os.environ.get('DB_PORT', '5432')
+DB_NAME = os.environ.get('DB_NAME', 'char_archive')
+DB_USER = os.environ.get('DB_USER', 'char_archive')
+DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
+
+SQL_DIR = Path(__file__).parent / 'sql'
+
+SOURCES = [
+    ('chub', 'chub_character_def', 'id'),
+    ('generic', 'generic_character_def', 'card_data_hash'),
+    ('booru', 'booru_character_def', 'id'),
+    ('webring', 'webring_character_def', 'card_data_hash'),
+    ('char_tavern', 'char_tavern_character_def', 'path'),
+    ('risuai', 'risuai_character_def', 'id'),
+    ('nyaime', 'nyaime_character_def', 'id'),
+]
+
+TAGS_JSON = "COALESCE(definition->'data'->'tags', definition->'tags', '[]'::jsonb)"
+
+
+def get_connection():
+    return psycopg2.connect(
+        host=DB_HOST,
+        port=DB_PORT,
+        dbname=DB_NAME,
+        user=DB_USER,
+        password=DB_PASSWORD,
+    )
+
+
+def apply_schema(cur):
+    schema_sql = (SQL_DIR / 'tag_index.sql').read_text()
+    cur.execute(schema_sql)
+
+
+def rebuild_source(cur, source, table, id_col):
+    print(f'  Indexing {source} ({table})...', flush=True)
+    started = time.time()
+
+    cur.execute('DELETE FROM character_tags WHERE source = %s', (source,))
+
+    insert_tags_sql = f"""
+        INSERT INTO character_tags (source, char_key, tag_norm, tag)
+        SELECT
+            %s,
+            latest.char_key,
+            lower(trim(tag)),
+            trim(tag)
+        FROM (
+            SELECT DISTINCT ON ({id_col}) {id_col}::text AS char_key, definition
+            FROM {table}
+            ORDER BY {id_col}, added DESC
+        ) latest
+        CROSS JOIN LATERAL jsonb_array_elements_text(
+            COALESCE(latest.definition->'data'->'tags', latest.definition->'tags', '[]'::jsonb)
+        ) AS tag
+        WHERE trim(tag) <> ''
+        ON CONFLICT (source, char_key, tag_norm) DO NOTHING
+    """
+    cur.execute(insert_tags_sql, (source,))
+
+    cur.execute('DELETE FROM tag_index WHERE source = %s', (source,))
+
+    cur.execute(
+        """
+        INSERT INTO tag_index (source, tag_norm, tag, count)
+        SELECT source, tag_norm, MIN(tag), COUNT(*)
+        FROM character_tags
+        WHERE source = %s
+        GROUP BY source, tag_norm
+        """,
+        (source,),
+    )
+
+    cur.execute('SELECT COUNT(*) FROM tag_index WHERE source = %s', (source,))
+    tag_count = cur.fetchone()[0]
+    elapsed = time.time() - started
+    print(f'    {tag_count:,} unique tags in {elapsed:.1f}s', flush=True)
+    return tag_count
+
+
+def main():
+    print(f'Connecting to {DB_HOST}:{DB_PORT}/{DB_NAME}...', flush=True)
+    conn = get_connection()
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    try:
+        print('Applying schema (tables, indexes, triggers)...', flush=True)
+        apply_schema(cur)
+        conn.commit()
+
+        print('Rebuilding tag index from latest character definitions...', flush=True)
+        total_tags = 0
+        for source, table, id_col in SOURCES:
+            total_tags += rebuild_source(cur, source, table, id_col)
+            conn.commit()
+
+        cur.execute('SELECT COUNT(*) FROM character_tags')
+        char_tag_rows = cur.fetchone()[0]
+        cur.execute('SELECT COUNT(*) FROM tag_index')
+        index_rows = cur.fetchone()[0]
+
+        print(flush=True)
+        print(f'Done. {index_rows:,} tag_index rows, {char_tag_rows:,} character_tags rows.', flush=True)
+        print('New cards will update the index automatically via database triggers.', flush=True)
+
+    except Exception as exc:
+        conn.rollback()
+        print(f'Error: {exc}', file=sys.stderr)
+        sys.exit(1)
+    finally:
+        cur.close()
+        conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/small_front/rebuild_tags.example.sh
+++ b/small_front/rebuild_tags.example.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Rebuild the tag index (run once after restoring the database, or after bulk imports).
+#
+# Setup:
+#   cp .env.example .env   # edit with your DB credentials
+#   cp rebuild_tags.example.sh rebuild_tags.sh
+#   chmod +x rebuild_tags.sh
+#   ./rebuild_tags.sh
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [[ ! -f .env ]]; then
+  echo "Missing .env — copy .env.example to .env and edit it." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+# shellcheck disable=SC1090
+. "${VENV_PATH:-~/venv}/bin/activate"
+exec python rebuild_tag_index.py

--- a/small_front/sql/tag_index.sql
+++ b/small_front/sql/tag_index.sql
@@ -1,0 +1,147 @@
+-- Tag index for fast autocomplete and tag-filter search.
+-- Run once, then use rebuild_tag_index.py to populate.
+-- Recommended to run this on a cron. Based on usage, adjust timing of cron
+CREATE TABLE IF NOT EXISTS character_tags (
+    source    TEXT NOT NULL,
+    char_key  TEXT NOT NULL,
+    tag_norm  TEXT NOT NULL,
+    tag       TEXT NOT NULL,
+    PRIMARY KEY (source, char_key, tag_norm)
+);
+
+CREATE INDEX IF NOT EXISTS character_tags_tag_norm_idx
+    ON character_tags (source, tag_norm);
+
+CREATE INDEX IF NOT EXISTS character_tags_tag_prefix_idx
+    ON character_tags (tag_norm text_pattern_ops);
+
+CREATE TABLE IF NOT EXISTS tag_index (
+    source    TEXT NOT NULL,
+    tag_norm  TEXT NOT NULL,
+    tag       TEXT NOT NULL,
+    count     BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (source, tag_norm)
+);
+
+CREATE INDEX IF NOT EXISTS tag_index_prefix_idx
+    ON tag_index (tag_norm text_pattern_ops);
+
+CREATE INDEX IF NOT EXISTS tag_index_count_idx
+    ON tag_index (source, count DESC);
+
+-- Sync character_tags + tag_index when a character definition is inserted/updated.
+CREATE OR REPLACE FUNCTION sync_character_tags_from_def()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_source   TEXT := TG_ARGV[0];
+    v_id_col   TEXT := TG_ARGV[1];
+    v_char_key TEXT;
+    v_tag      TEXT;
+    v_tag_norm TEXT;
+    v_old_norms TEXT[];
+    v_new_norms TEXT[];
+    v_all_norms TEXT[];
+    v_norm     TEXT;
+    v_count    BIGINT;
+    v_display  TEXT;
+BEGIN
+    EXECUTE format('SELECT ($1).%I::text', v_id_col) INTO v_char_key USING NEW;
+
+    SELECT COALESCE(array_agg(DISTINCT tag_norm), ARRAY[]::TEXT[])
+    INTO v_old_norms
+    FROM character_tags
+    WHERE source = v_source AND char_key = v_char_key;
+
+    DELETE FROM character_tags
+    WHERE source = v_source AND char_key = v_char_key;
+
+    v_new_norms := ARRAY[]::TEXT[];
+
+    FOR v_tag IN
+        SELECT trim(elem.tag)
+        FROM jsonb_array_elements_text(
+            COALESCE(NEW.definition->'data'->'tags', NEW.definition->'tags', '[]'::jsonb)
+        ) AS elem(tag)
+    LOOP
+        IF v_tag = '' THEN
+            CONTINUE;
+        END IF;
+
+        v_tag_norm := lower(v_tag);
+
+        INSERT INTO character_tags (source, char_key, tag_norm, tag)
+        VALUES (v_source, v_char_key, v_tag_norm, v_tag)
+        ON CONFLICT (source, char_key, tag_norm) DO NOTHING;
+
+        IF NOT v_tag_norm = ANY(v_new_norms) THEN
+            v_new_norms := array_append(v_new_norms, v_tag_norm);
+        END IF;
+    END LOOP;
+
+    SELECT array_agg(DISTINCT n)
+    INTO v_all_norms
+    FROM unnest(v_old_norms || v_new_norms) AS n;
+
+    IF v_all_norms IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    FOREACH v_norm IN ARRAY v_all_norms
+    LOOP
+        SELECT COUNT(*), MIN(tag)
+        INTO v_count, v_display
+        FROM character_tags
+        WHERE source = v_source AND tag_norm = v_norm;
+
+        IF v_count = 0 THEN
+            DELETE FROM tag_index
+            WHERE source = v_source AND tag_norm = v_norm;
+        ELSE
+            INSERT INTO tag_index (source, tag_norm, tag, count)
+            VALUES (v_source, v_norm, v_display, v_count)
+            ON CONFLICT (source, tag_norm)
+            DO UPDATE SET
+                count = EXCLUDED.count,
+                tag = EXCLUDED.tag;
+        END IF;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Triggers on all character definition tables
+DROP TRIGGER IF EXISTS trg_sync_tags ON chub_character_def;
+CREATE TRIGGER trg_sync_tags
+    AFTER INSERT OR UPDATE OF definition ON chub_character_def
+    FOR EACH ROW EXECUTE PROCEDURE sync_character_tags_from_def('chub', 'id');
+
+DROP TRIGGER IF EXISTS trg_sync_tags ON generic_character_def;
+CREATE TRIGGER trg_sync_tags
+    AFTER INSERT OR UPDATE OF definition ON generic_character_def
+    FOR EACH ROW EXECUTE PROCEDURE sync_character_tags_from_def('generic', 'card_data_hash');
+
+DROP TRIGGER IF EXISTS trg_sync_tags ON booru_character_def;
+CREATE TRIGGER trg_sync_tags
+    AFTER INSERT OR UPDATE OF definition ON booru_character_def
+    FOR EACH ROW EXECUTE PROCEDURE sync_character_tags_from_def('booru', 'id');
+
+DROP TRIGGER IF EXISTS trg_sync_tags ON webring_character_def;
+CREATE TRIGGER trg_sync_tags
+    AFTER INSERT OR UPDATE OF definition ON webring_character_def
+    FOR EACH ROW EXECUTE PROCEDURE sync_character_tags_from_def('webring', 'card_data_hash');
+
+DROP TRIGGER IF EXISTS trg_sync_tags ON char_tavern_character_def;
+CREATE TRIGGER trg_sync_tags
+    AFTER INSERT OR UPDATE OF definition ON char_tavern_character_def
+    FOR EACH ROW EXECUTE PROCEDURE sync_character_tags_from_def('char_tavern', 'path');
+
+DROP TRIGGER IF EXISTS trg_sync_tags ON risuai_character_def;
+CREATE TRIGGER trg_sync_tags
+    AFTER INSERT OR UPDATE OF definition ON risuai_character_def
+    FOR EACH ROW EXECUTE PROCEDURE sync_character_tags_from_def('risuai', 'id');
+
+DROP TRIGGER IF EXISTS trg_sync_tags ON nyaime_character_def;
+CREATE TRIGGER trg_sync_tags
+    AFTER INSERT OR UPDATE OF definition ON nyaime_character_def
+    FOR EACH ROW EXECUTE PROCEDURE sync_character_tags_from_def('nyaime', 'id');

--- a/small_front/templates/index.html
+++ b/small_front/templates/index.html
@@ -94,6 +94,7 @@
         .line-clamp-2 {
             display: -webkit-box;
             -webkit-line-clamp: 2;
+            line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
         }
@@ -217,6 +218,31 @@
             0%, 100% { opacity: 0.7; }
             50% { opacity: 1; }
         }
+        /* Clickable filter chips on cards and modal */
+        .filter-author,
+        .filter-tag {
+            cursor: pointer;
+        }
+        .filter-author:hover,
+        .filter-tag:hover {
+            color: #c4b5fd;
+        }
+        .tag-expand {
+            cursor: pointer;
+        }
+        .tag-expand:hover {
+            color: #c4b5fd;
+        }
+
+        /* Tag picker autocomplete */
+        .tag-picker:focus-within {
+            border-color: rgba(139, 92, 246, 0.7);
+            box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15), 0 0 20px rgba(139, 92, 246, 0.1);
+        }
+        .tag-suggestion.active {
+            background: #1e1e24;
+            color: #c4b5fd;
+        }
     </style>
 </head>
 <body class="h-full text-gray-100">
@@ -225,11 +251,13 @@
         <header class="bg-dark-card/80 backdrop-blur-md border-b border-dark-border/50 sticky top-0 z-50">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                    <h1 class="text-2xl sm:text-3xl font-bold tracking-tight">
-                        <span class="gradient-text">Character</span>
-                        <span class="text-white"> Archive</span>
-                    </h1>
-                    <div id="stats" class="text-sm text-purple-300/70 font-medium pulse-subtle"></div>
+                    <a href="/" class="block no-underline hover:opacity-90 transition-opacity w-fit" title="Home">
+                        <h1 class="text-2xl sm:text-3xl font-bold tracking-tight">
+                            <span class="gradient-text">Character</span>
+                            <span class="text-white"> Archive</span>
+                        </h1>
+                    </a>
+                    <div id="stats" class="text-sm text-purple-300/70 font-medium pulse-subtle{% if browse_all_enabled %} cursor-pointer hover:text-purple-300 transition-colors{% endif %}"{% if browse_all_enabled %} title="Browse all characters"{% endif %}></div>
                 </div>
             </div>
         </header>
@@ -239,42 +267,62 @@
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10">
                 <!-- Search heading -->
                 <div class="text-center mb-6">
-                    <h2 class="text-lg sm:text-xl text-gray-300 font-medium">Find your perfect character</h2>
+                    <h2 class="text-lg sm:text-xl text-gray-300 font-medium">Search by name, author, or tags</h2>
                 </div>
 
-                <div class="flex flex-col sm:flex-row gap-3 max-w-4xl mx-auto">
-                    <div class="flex-1">
-                        <div class="relative group">
-                            <input
-                                type="text"
-                                id="searchInput"
-                                placeholder="Search characters by name or author..."
-                                class="w-full bg-dark-bg/80 border-2 border-dark-border rounded-xl px-5 py-4 pl-12 text-white placeholder-gray-500 focus:outline-none focus:border-purple-500/70 transition-all duration-300 search-glow"
-                            >
-                            <svg class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500 group-focus-within:text-purple-400 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-                            </svg>
-                        </div>
+                <div class="flex flex-col gap-3 max-w-4xl mx-auto">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <input
+                            type="text"
+                            id="nameFilter"
+                            placeholder="Name..."
+                            class="w-full bg-dark-bg/80 border-2 border-dark-border rounded-xl px-5 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-purple-500/70 transition-all duration-300 search-glow"
+                        >
+                        <input
+                            type="text"
+                            id="authorFilter"
+                            placeholder="Author / uploader..."
+                            class="w-full bg-dark-bg/80 border-2 border-dark-border rounded-xl px-5 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-purple-500/70 transition-all duration-300 search-glow"
+                        >
                     </div>
-                    <div class="flex gap-3">
-                        <select id="sourceFilter" class="bg-dark-bg/80 border-2 border-dark-border rounded-xl px-4 py-4 text-white focus:outline-none focus:border-purple-500/70 transition-all duration-300 cursor-pointer hover:border-dark-hover">
+                    <div id="tagPicker" class="tag-picker relative bg-dark-bg/80 border-2 border-dark-border rounded-xl px-3 py-2 transition-all duration-300">
+                        <div id="tagChips" class="flex flex-wrap gap-1.5 mb-1 empty:mb-0"></div>
+                        <input
+                            type="text"
+                            id="tagInput"
+                            autocomplete="off"
+                            placeholder="Tags: type name, or -name to exclude (e.g. -female)..."
+                            class="w-full bg-transparent px-2 py-1.5 text-white placeholder-gray-500 focus:outline-none"
+                        >
+                        <div id="tagSuggestions" class="hidden absolute left-0 right-0 top-full mt-1 z-40 max-h-56 overflow-y-auto bg-dark-card border border-dark-border rounded-xl shadow-card"></div>
+                    </div>
+                    <div class="flex flex-col sm:flex-row gap-3">
+                        <select id="sourceFilter" class="flex-1 bg-dark-bg/80 border-2 border-dark-border rounded-xl px-4 py-3 text-white focus:outline-none focus:border-purple-500/70 transition-all duration-300 cursor-pointer hover:border-dark-hover">
                             <option value="all">All Sources</option>
-                            <option value="chub">Chub</option>
-                            <option value="generic">Generic</option>
-                            <option value="booru">Booru</option>
-                            <option value="webring">Webring</option>
-                            <option value="char_tavern">Character Tavern</option>
-                            <option value="risuai">RisuAI</option>
-                            <option value="nyaime">Nyaime</option>
+                            {% for src in sources %}
+                            <option value="{{ src.id }}">{{ src.label }}</option>
+                            {% endfor %}
+                        </select>
+                        <select id="sortFilter" class="flex-1 bg-dark-bg/80 border-2 border-dark-border rounded-xl px-4 py-3 text-white focus:outline-none focus:border-purple-500/70 transition-all duration-300 cursor-pointer hover:border-dark-hover">
+                            <option value="added:desc">Newest first</option>
+                            <option value="added:asc">Oldest first</option>
+                            <option value="name:asc">Name A–Z</option>
+                            <option value="name:desc">Name Z–A</option>
                         </select>
                         <button
                             id="searchBtn"
-                            class="btn-primary text-white px-8 py-4 rounded-xl font-semibold flex items-center gap-2 whitespace-nowrap"
+                            class="btn-primary text-white px-8 py-3 rounded-xl font-semibold flex items-center justify-center gap-2 whitespace-nowrap"
                         >
                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                             </svg>
                             Search
+                        </button>
+                        <button
+                            id="clearBtn"
+                            class="bg-dark-bg/80 hover:bg-dark-hover border-2 border-dark-border text-gray-300 px-6 py-3 rounded-xl font-semibold transition-all duration-300 hover:border-purple-500/30 whitespace-nowrap"
+                        >
+                            Clear
                         </button>
                     </div>
                 </div>
@@ -334,13 +382,14 @@
                 </div>
                 <h2 class="text-3xl sm:text-4xl font-bold text-white mb-4">Welcome to the <span class="gradient-text">Character Archive</span></h2>
                 <p class="text-gray-400 max-w-lg mx-auto text-lg leading-relaxed">
-                    Search through hundreds of thousands of AI character cards preserved from various platforms.
+                    Filter by name, author, or tags across hundreds of thousands of AI character cards preserved from various platforms.
                 </p>
-                <div class="mt-8 flex flex-wrap justify-center gap-3">
-                    <span class="px-4 py-2 rounded-full bg-dark-card border border-dark-border text-sm text-gray-400">Chub</span>
-                    <span class="px-4 py-2 rounded-full bg-dark-card border border-dark-border text-sm text-gray-400">Character Tavern</span>
-                    <span class="px-4 py-2 rounded-full bg-dark-card border border-dark-border text-sm text-gray-400">RisuAI</span>
-                    <span class="px-4 py-2 rounded-full bg-dark-card border border-dark-border text-sm text-gray-400">and more</span>
+                <div class="mt-8 flex flex-wrap justify-center gap-3" id="sourceBrowse">
+                    {% for src in sources %}
+                    <a href="/?source={{ src.id }}"
+                       class="source-browse px-4 py-2 rounded-full bg-dark-card border border-dark-border text-sm text-gray-400 hover:text-purple-300 hover:border-purple-500/40 transition-colors no-underline"
+                       data-source="{{ src.id }}">{{ src.label }}</a>
+                    {% endfor %}
                 </div>
             </div>
 
@@ -384,16 +433,27 @@
     </div>
 
     <script>
+        const OPEN_CHARACTER = {{ open_character | tojson }};
+        const BROWSE_ALL_ENABLED = {{ browse_all_enabled | tojson }};
+        const SOURCES = {{ sources | tojson }};
+        const SOURCE_IDS = new Set(SOURCES.map(s => s.id));
+
         // State
         let currentPage = 1;
-        let currentQuery = '';
-        let currentSource = 'all';
         let totalPages = 1;
+        let browseAllMode = false;
 
         // Elements
-        const searchInput = document.getElementById('searchInput');
+        const nameFilter = document.getElementById('nameFilter');
+        const authorFilter = document.getElementById('authorFilter');
+        const tagInput = document.getElementById('tagInput');
+        const tagChips = document.getElementById('tagChips');
+        const tagSuggestions = document.getElementById('tagSuggestions');
+        const tagPicker = document.getElementById('tagPicker');
         const searchBtn = document.getElementById('searchBtn');
+        const clearBtn = document.getElementById('clearBtn');
         const sourceFilter = document.getElementById('sourceFilter');
+        const sortFilter = document.getElementById('sortFilter');
         const results = document.getElementById('results');
         const loading = document.getElementById('loading');
         const noResults = document.getElementById('noResults');
@@ -415,7 +475,7 @@
             try {
                 const response = await fetch('/api/stats');
                 const data = await response.json();
-                stats.textContent = `${data.total.toLocaleString()} characters archived`;
+                stats.textContent = `${data.total.toLocaleString()} Characters Archived`;
             } catch (e) {
                 console.error('Failed to load stats:', e);
             }
@@ -436,63 +496,400 @@
             }
         }
 
-        // Search function
-        async function search(page = 1) {
-            const query = searchInput.value.trim();
-            if (!query) return;
+        // Tag picker state
+        let selectedTags = [];
+        let tagSuggestTimeout = null;
+        let tagSuggestIndex = -1;
 
-            currentQuery = query;
-            currentSource = sourceFilter.value;
+        function tagBaseName(tag) {
+            return (tag || '').replace(/^-/, '').trim().toLowerCase();
+        }
+
+        function isExcludeTag(tag) {
+            return (tag || '').trim().startsWith('-') && tag.trim().length > 1;
+        }
+
+        function renderTagChips() {
+            tagChips.innerHTML = selectedTags.map(tag => {
+                const exclude = isExcludeTag(tag);
+                const label = exclude ? tag.trim().slice(1) : tag.trim();
+                const chipClass = exclude
+                    ? 'bg-red-500/15 text-red-300 border-red-500/30'
+                    : 'bg-purple-500/15 text-purple-300 border-purple-500/30';
+                const removeClass = exclude ? 'text-red-300/70 hover:text-white' : 'text-purple-300/70 hover:text-white';
+                return `
+                <span class="inline-flex items-center gap-1 ${chipClass} text-xs px-2.5 py-1 rounded-full border">
+                    ${exclude ? '<span aria-hidden="true">−</span>' : ''}${escapeHtml(label)}
+                    <button type="button" class="tag-chip-remove ${removeClass} leading-none" data-tag="${escapeAttr(tag)}" aria-label="Remove ${escapeAttr(label)}">&times;</button>
+                </span>`;
+            }).join('');
+        }
+
+        function addSelectedTag(tag, autoSearch = false) {
+            let value = (tag || '').trim();
+            if (!value) return false;
+
+            const exclude = value.startsWith('-') && value.length > 1;
+            if (exclude) {
+                value = '-' + value.slice(1).trim();
+            } else {
+                value = value.replace(/^-+/, '');
+            }
+            if (!value || value === '-') return false;
+
+            const base = tagBaseName(value);
+            selectedTags = selectedTags.filter(t => tagBaseName(t) !== base);
+            selectedTags.push(value);
+            renderTagChips();
+            tagInput.value = '';
+            hideTagSuggestions();
+            if (autoSearch && hasActiveFilters()) search(1);
+            return true;
+        }
+
+        function removeSelectedTag(tag) {
+            const base = tagBaseName(tag);
+            selectedTags = selectedTags.filter(t => tagBaseName(t) !== base);
+            renderTagChips();
+        }
+
+        function setSelectedTagsFromString(str) {
+            const seen = new Set();
+            selectedTags = (str || '').split(',').map(t => t.trim()).filter(t => {
+                if (!t || t === '-') return false;
+                const base = tagBaseName(t);
+                if (seen.has(base)) return false;
+                seen.add(base);
+                return true;
+            }).map(t => isExcludeTag(t) ? '-' + t.replace(/^-+/, '') : t.replace(/^-+/, ''));
+            renderTagChips();
+        }
+
+        function getTagsParam() {
+            return selectedTags.join(',');
+        }
+
+        async function fetchTagSuggestions(query) {
+            const params = new URLSearchParams({ limit: '30', q: query });
+            if (sourceFilter.value !== 'all') params.set('source', sourceFilter.value);
+            const response = await fetch(`/api/tags?${params}`);
+            const data = await response.json();
+            return data.tags || [];
+        }
+
+        function highlightSuggestion(index) {
+            tagSuggestions.querySelectorAll('.tag-suggestion').forEach((el, i) => {
+                el.classList.toggle('active', i === index);
+            });
+        }
+
+        function showTagSuggestions(tags) {
+            const available = tags.filter(item =>
+                !selectedTags.some(t => tagBaseName(t) === item.tag.toLowerCase())
+            );
+            if (!available.length) {
+                hideTagSuggestions();
+                return;
+            }
+            const excluding = tagInput.value.trim().startsWith('-');
+            tagSuggestIndex = -1;
+            tagSuggestions.innerHTML = available.map((item, i) => `
+                <button type="button"
+                        class="tag-suggestion w-full text-left px-4 py-2.5 text-sm text-gray-300 hover:bg-dark-hover hover:text-purple-300 flex justify-between gap-3 border-b border-dark-border/30 last:border-0"
+                        data-tag="${escapeAttr(excluding ? '-' + item.tag : item.tag)}"
+                        data-index="${i}">
+                    <span class="truncate">${excluding ? '− ' : ''}${escapeHtml(item.tag)}</span>
+                    <span class="text-gray-500 text-xs flex-shrink-0">${Number(item.count).toLocaleString()}</span>
+                </button>
+            `).join('');
+            tagSuggestions.classList.remove('hidden');
+        }
+
+        function hideTagSuggestions() {
+            tagSuggestions.classList.add('hidden');
+            tagSuggestIndex = -1;
+        }
+
+        function tagInputReady() {
+            const raw = tagInput.value.trim();
+            const query = raw.startsWith('-') ? raw.slice(1).trim() : raw;
+            return query.length >= 2;
+        }
+
+        function scheduleTagSuggestions() {
+            clearTimeout(tagSuggestTimeout);
+            tagSuggestTimeout = setTimeout(async () => {
+                const raw = tagInput.value.trim();
+                const query = raw.startsWith('-') ? raw.slice(1).trim() : raw;
+                if (query.length < 2) {
+                    hideTagSuggestions();
+                    return;
+                }
+                try {
+                    const tags = await fetchTagSuggestions(query);
+                    showTagSuggestions(tags);
+                } catch (e) {
+                    console.error('Tag suggestions failed:', e);
+                    hideTagSuggestions();
+                }
+            }, 250);
+        }
+
+        function selectSuggestionTag(tag) {
+            addSelectedTag(tag, true);
+            tagInput.focus();
+        }
+
+        function selectActiveSuggestion() {
+            const items = tagSuggestions.querySelectorAll('.tag-suggestion');
+            if (!items.length) return false;
+            const index = tagSuggestIndex >= 0 ? tagSuggestIndex : 0;
+            selectSuggestionTag(items[index].dataset.tag);
+            return true;
+        }
+
+        // Filter helpers
+        function getSortValues() {
+            const [sort, order] = sortFilter.value.split(':');
+            return { sort, order };
+        }
+
+        function hasActiveFilters() {
+            return (BROWSE_ALL_ENABLED && browseAllMode)
+                || nameFilter.value.trim()
+                || authorFilter.value.trim()
+                || selectedTags.length > 0
+                || sourceFilter.value !== 'all';
+        }
+
+        function buildSearchParams(page = 1) {
+            const params = new URLSearchParams();
+            const name = nameFilter.value.trim();
+            const author = authorFilter.value.trim();
+            const tags = getTagsParam();
+            const source = sourceFilter.value;
+            const { sort, order } = getSortValues();
+
+            if (name) params.set('name', name);
+            if (author) params.set('author', author);
+            if (tags) params.set('tags', tags);
+            if (source !== 'all') params.set('source', source);
+            if (BROWSE_ALL_ENABLED && browseAllMode && !name && !author && !tags && source === 'all') {
+                params.set('browse', 'all');
+            }
+            if (sort !== 'added' || order !== 'desc') {
+                params.set('sort', sort);
+                params.set('order', order);
+            }
+            if (page > 1) params.set('page', String(page));
+
+            return params;
+        }
+
+        function buildAppUrl(page = 1) {
+            const params = buildSearchParams(page);
+            const query = params.toString();
+            return query ? `/?${query}` : '/';
+        }
+
+        function applyParamsToFilters(params) {
+            nameFilter.value = params.get('name') || '';
+            authorFilter.value = params.get('author') || '';
+            setSelectedTagsFromString(params.get('tags') || '');
+            const sourceParam = params.get('source') || 'all';
+            sourceFilter.value = SOURCE_IDS.has(sourceParam) ? sourceParam : 'all';
+            browseAllMode = BROWSE_ALL_ENABLED && params.get('browse') === 'all';
+
+            const sort = params.get('sort') || 'added';
+            const order = params.get('order') || 'desc';
+            sortFilter.value = `${sort}:${order}`;
+        }
+
+        function clearFilters() {
+            browseAllMode = false;
+            nameFilter.value = '';
+            authorFilter.value = '';
+            selectedTags = [];
+            renderTagChips();
+            tagInput.value = '';
+            hideTagSuggestions();
+            sourceFilter.value = 'all';
+            sortFilter.value = 'added:desc';
+            currentPage = 1;
+            results.innerHTML = '';
+            noResults.classList.add('hidden');
+            resultsInfo.classList.add('hidden');
+            pagination.classList.add('hidden');
+            welcome.classList.remove('hidden');
+            history.replaceState(null, '', '/');
+        }
+
+        function browseAllCharacters() {
+            if (!BROWSE_ALL_ENABLED) return;
+            nameFilter.value = '';
+            authorFilter.value = '';
+            selectedTags = [];
+            renderTagChips();
+            tagInput.value = '';
+            hideTagSuggestions();
+            sourceFilter.value = 'all';
+            sortFilter.value = 'added:desc';
+            browseAllMode = true;
+            closeModalHandler();
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+            search(1);
+        }
+
+        function browseSource(source) {
+            browseAllMode = false;
+            nameFilter.value = '';
+            authorFilter.value = '';
+            selectedTags = [];
+            renderTagChips();
+            tagInput.value = '';
+            hideTagSuggestions();
+            sourceFilter.value = source;
+            sortFilter.value = 'added:desc';
+            closeModalHandler();
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+            search(1);
+        }
+
+        function filterByAuthor(author) {
+            const value = (author || '').trim();
+            if (!value || value === 'Unknown author' || value === 'Unknown') return;
+            authorFilter.value = value;
+            closeModalHandler();
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+            search(1);
+        }
+
+        function filterByTag(tag) {
+            const value = (tag || '').trim();
+            if (!value) return;
+            addSelectedTag(value);
+            closeModalHandler();
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+            search(1);
+        }
+
+        function expandModalTags(expandBtn) {
+            const container = expandBtn.closest('.tag-list');
+            if (!container) return;
+            container.querySelector('.tag-extra')?.classList.remove('hidden');
+            expandBtn.remove();
+        }
+
+        function buildTagFilterUrl(tag) {
+            const params = new URLSearchParams();
+            params.set('tags', tag.trim());
+            return `/?${params.toString()}`;
+        }
+
+        function renderModalAuthor(author) {
+            const value = (author || '').trim();
+            if (!value || value === 'Unknown') {
+                return `<p class="text-gray-400 text-base">by <span class="text-purple-400 font-medium">Unknown</span></p>`;
+            }
+            return `<p class="text-gray-400 text-base">by <button type="button" class="filter-author text-purple-400 font-medium hover:underline cursor-pointer bg-transparent border-0 p-0" data-author="${escapeAttr(value)}">${escapeHtml(value)}</button></p>`;
+        }
+
+        function renderModalTags(tags) {
+            if (!tags.length) return '';
+
+            const limit = 10;
+            const normalized = tags.map(t => String(t).trim()).filter(Boolean);
+            const renderTagBtn = (tag) => `
+                <a href="${buildTagFilterUrl(tag)}"
+                   class="filter-tag inline-block bg-dark-bg text-xs px-2.5 py-1 rounded-full text-gray-400 border border-dark-border/50 hover:border-purple-500/50 hover:text-purple-300 transition-colors no-underline"
+                   data-tag="${escapeAttr(tag)}"
+                   title="Filter by tag: ${escapeHtml(tag)}">${escapeHtml(tag)}</a>`;
+
+            const visible = normalized.slice(0, limit).map(renderTagBtn).join('');
+            const hidden = normalized.slice(limit);
+            const hiddenHtml = hidden.length
+                ? `<span class="tag-extra hidden flex flex-wrap gap-1.5">${hidden.map(renderTagBtn).join('')}</span>`
+                : '';
+            const expandBtn = hidden.length
+                ? `<button type="button" class="tag-expand text-xs text-purple-400 hover:text-purple-300 px-2 py-1">+${hidden.length} more</button>`
+                : '';
+
+            return `
+                <div class="mb-5">
+                    <div class="tag-list flex flex-wrap gap-1.5 items-center">
+                        ${visible}${expandBtn}${hiddenHtml}
+                    </div>
+                </div>
+            `;
+        }
+
+        function renderCard(char) {
+            const cardUrl = `/character/${encodeURIComponent(char.source)}/${encodeURIComponent(String(char.id))}`;
+            return `
+                <a href="${cardUrl}"
+                   class="character-card block bg-dark-card rounded-2xl overflow-hidden border border-dark-border/50 hover:border-purple-500/40 transition-all duration-300 cursor-pointer fade-in group card-lift shadow-card hover:shadow-card-hover no-underline"
+                   data-source="${escapeHtml(char.source)}"
+                   data-id="${escapeHtml(String(char.id))}">
+                    <div class="relative overflow-hidden">
+                        <img
+                            src="/image/${char.image_hash}"
+                            alt="${escapeHtml(char.name || 'Character')}"
+                            class="card-image w-full object-cover group-hover:scale-105 transition-transform duration-500 ease-out"
+                            loading="lazy"
+                            onerror="this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><rect fill=%22%23141418%22 width=%22100%22 height=%22100%22/><text x=%2250%22 y=%2250%22 text-anchor=%22middle%22 dy=%22.3em%22 fill=%22%23444%22 font-size=%2240%22>?</text></svg>'"
+                        >
+                        <div class="absolute inset-0 image-overlay opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                        <div class="absolute top-2.5 right-2.5">
+                            <span class="bg-dark-bg/90 backdrop-blur-sm text-xs px-2.5 py-1 rounded-full text-gray-300 border border-dark-border/50 font-medium">${escapeHtml(char.source)}</span>
+                        </div>
+                    </div>
+                    <div class="p-4">
+                        <h3 class="font-semibold text-white truncate text-sm sm:text-base group-hover:text-purple-300 transition-colors duration-300">${escapeHtml(char.name || 'Unnamed')}</h3>
+                        ${char.author
+                            ? `<p class="text-sm text-gray-400 truncate mt-1">by <span role="button" tabindex="0" class="filter-author text-purple-400/80 hover:text-purple-300 hover:underline" data-author="${escapeAttr(char.author)}">${escapeHtml(char.author)}</span></p>`
+                            : `<p class="text-sm text-gray-400 truncate mt-1">Unknown author</p>`}
+                        ${char.tagline ? `<p class="text-xs text-gray-400 mt-2 line-clamp-2 leading-relaxed">${escapeHtml(cleanCardText(char.tagline))}</p>` : ''}
+                    </div>
+                </a>
+            `;
+        }
+
+        // Search function
+        async function search(page = 1, updateUrl = true) {
+            if (!hasActiveFilters()) {
+                clearFilters();
+                return;
+            }
+
             currentPage = page;
+
+            if (updateUrl) {
+                history.replaceState(null, '', buildAppUrl(page));
+            }
 
             showLoading();
 
             try {
-                const response = await fetch(`/api/search?q=${encodeURIComponent(query)}&source=${currentSource}&page=${page}&per_page=24`);
+                const params = buildSearchParams(page);
+                params.set('per_page', '24');
+                const response = await fetch(`/api/search?${params}`);
                 const data = await response.json();
 
                 loading.classList.add('hidden');
 
                 if (data.results.length === 0) {
+                    results.innerHTML = '';
                     noResults.classList.remove('hidden');
                     resultsInfo.classList.add('hidden');
                     pagination.classList.add('hidden');
                     return;
                 }
 
-                // Update results info
+                noResults.classList.add('hidden');
                 resultsInfo.classList.remove('hidden');
                 resultCount.textContent = `Found ${data.total.toLocaleString()} characters`;
+                results.innerHTML = data.results.map(renderCard).join('');
 
-                // Render results with enhanced card design
-                results.innerHTML = data.results.map(char => `
-                    <div class="character-card bg-dark-card rounded-2xl overflow-hidden border border-dark-border/50 hover:border-purple-500/40 transition-all duration-300 cursor-pointer fade-in group card-lift shadow-card hover:shadow-card-hover"
-                         data-source="${escapeHtml(char.source)}"
-                         data-id="${escapeHtml(String(char.id))}">
-                        <div class="relative overflow-hidden">
-                            <img
-                                src="/image/${char.image_hash}"
-                                alt="${escapeHtml(char.name || 'Character')}"
-                                class="card-image w-full object-cover group-hover:scale-105 transition-transform duration-500 ease-out"
-                                loading="lazy"
-                                onerror="this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><rect fill=%22%23141418%22 width=%22100%22 height=%22100%22/><text x=%2250%22 y=%2250%22 text-anchor=%22middle%22 dy=%22.3em%22 fill=%22%23444%22 font-size=%2240%22>?</text></svg>'"
-                            >
-                            <!-- Gradient overlay -->
-                            <div class="absolute inset-0 image-overlay opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                            <!-- Source badge -->
-                            <div class="absolute top-2.5 right-2.5">
-                                <span class="bg-dark-bg/90 backdrop-blur-sm text-xs px-2.5 py-1 rounded-full text-gray-300 border border-dark-border/50 font-medium">${escapeHtml(char.source)}</span>
-                            </div>
-                        </div>
-                        <div class="p-4">
-                            <h3 class="font-semibold text-white truncate text-sm sm:text-base group-hover:text-purple-300 transition-colors duration-300">${escapeHtml(char.name || 'Unnamed')}</h3>
-                            <p class="text-sm text-gray-400 truncate mt-1">${escapeHtml(char.author || 'Unknown author')}</p>
-                            ${char.tagline ? `<p class="text-xs text-gray-400 mt-2 line-clamp-2 leading-relaxed">${escapeHtml(cleanCardText(char.tagline))}</p>` : ''}
-                        </div>
-                    </div>
-                `).join('');
-
-                // Update pagination
                 totalPages = data.pages;
                 if (totalPages > 1) {
                     pagination.classList.remove('hidden');
@@ -508,6 +905,19 @@
                 loading.classList.add('hidden');
                 noResults.classList.remove('hidden');
             }
+        }
+
+        function initFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            if (!params.toString()) return false;
+
+            applyParamsToFilters(params);
+            const page = Math.max(parseInt(params.get('page') || '1', 10), 1);
+            if (hasActiveFilters()) {
+                search(page, false);
+                return true;
+            }
+            return false;
         }
 
         // Show character details with enhanced modal
@@ -589,7 +999,7 @@
                             <!-- Header -->
                             <div class="mb-5">
                                 <h2 class="text-2xl sm:text-3xl font-bold text-white mb-2">${escapeHtml(char.name || 'Unnamed Character')}</h2>
-                                <p class="text-gray-400 text-base">by <span class="text-purple-400 font-medium">${escapeHtml(char.author || 'Unknown')}</span></p>
+                                ${renderModalAuthor(char.author)}
                             </div>
 
                             <!-- Meta badges -->
@@ -598,15 +1008,7 @@
                                 ${char.added ? `<span class="bg-dark-bg text-gray-400 text-xs px-3 py-1.5 rounded-full font-medium border border-dark-border">${new Date(char.added).toLocaleDateString()}</span>` : ''}
                             </div>
 
-                            <!-- Tags -->
-                            ${tags.length > 0 ? `
-                                <div class="mb-5">
-                                    <div class="flex flex-wrap gap-1.5">
-                                        ${tags.slice(0, 10).map(tag => `<span class="bg-dark-bg text-xs px-2.5 py-1 rounded-full text-gray-400 border border-dark-border/50 hover:border-purple-500/30 transition-colors">${escapeHtml(tag.trim())}</span>`).join('')}
-                                        ${tags.length > 10 ? `<span class="text-xs text-gray-500 px-2 py-1">+${tags.length - 10} more</span>` : ''}
-                                    </div>
-                                </div>
-                            ` : ''}
+                            ${renderModalTags(tags)}
 
                             <!-- Description -->
                             ${description ? `
@@ -661,6 +1063,10 @@
             return div.innerHTML;
         }
 
+        function escapeAttr(text) {
+            return escapeHtml(text).replace(/"/g, '&quot;');
+        }
+
         // Clean up character card formatting from text
         function cleanCardText(text) {
             if (!text) return '';
@@ -690,11 +1096,69 @@
 
         // Event listeners
         searchBtn.addEventListener('click', () => search(1));
-        searchInput.addEventListener('keypress', (e) => {
-            if (e.key === 'Enter') search(1);
+        clearBtn.addEventListener('click', clearFilters);
+        [nameFilter, authorFilter].forEach(el => {
+            el.addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') search(1);
+            });
         });
+
+        tagInput.addEventListener('input', scheduleTagSuggestions);
+        tagInput.addEventListener('focus', scheduleTagSuggestions);
+        tagInput.addEventListener('keydown', (e) => {
+            const items = tagSuggestions.querySelectorAll('.tag-suggestion');
+            if (e.key === 'ArrowDown' && items.length) {
+                e.preventDefault();
+                tagSuggestIndex = Math.min(tagSuggestIndex + 1, items.length - 1);
+                highlightSuggestion(tagSuggestIndex);
+            } else if (e.key === 'ArrowUp' && items.length) {
+                e.preventDefault();
+                tagSuggestIndex = Math.max(tagSuggestIndex - 1, 0);
+                highlightSuggestion(tagSuggestIndex);
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                if (tagSuggestions.classList.contains('hidden')) {
+                    if (tagInputReady()) {
+                        addSelectedTag(tagInput.value.trim(), true);
+                    }
+                } else if (!selectActiveSuggestion() && tagInputReady()) {
+                    addSelectedTag(tagInput.value.trim(), true);
+                }
+            } else if (e.key === 'Escape') {
+                hideTagSuggestions();
+            } else if (e.key === 'Backspace' && !tagInput.value && selectedTags.length) {
+                removeSelectedTag(selectedTags[selectedTags.length - 1]);
+            }
+        });
+
+        tagChips.addEventListener('click', (e) => {
+            const btn = e.target.closest('.tag-chip-remove');
+            if (btn) {
+                e.preventDefault();
+                removeSelectedTag(btn.dataset.tag);
+                if (hasActiveFilters()) search(1);
+            }
+        });
+
+        tagSuggestions.addEventListener('click', (e) => {
+            const btn = e.target.closest('.tag-suggestion');
+            if (btn) {
+                e.preventDefault();
+                selectSuggestionTag(btn.dataset.tag);
+            }
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!tagPicker.contains(e.target)) hideTagSuggestions();
+        });
+
         sourceFilter.addEventListener('change', () => {
-            if (currentQuery) search(1);
+            hideTagSuggestions();
+            if (tagInputReady()) scheduleTagSuggestions();
+            if (hasActiveFilters()) search(1);
+        });
+        sortFilter.addEventListener('change', () => {
+            if (hasActiveFilters()) search(1);
         });
         prevPage.addEventListener('click', () => search(currentPage - 1));
         nextPage.addEventListener('click', () => search(currentPage + 1));
@@ -704,21 +1168,67 @@
             if (e.key === 'Escape') closeModalHandler();
         });
 
-        // Event delegation for character cards (handles special characters in IDs)
+        // Normal click opens modal; modified click opens link in new tab
         results.addEventListener('click', (e) => {
-            const card = e.target.closest('.character-card');
-            if (card) {
-                const source = card.dataset.source;
-                const id = card.dataset.id;
-                if (source && id) {
-                    showCharacter(source, id);
-                }
+            const authorEl = e.target.closest('.filter-author');
+            if (authorEl) {
+                e.preventDefault();
+                e.stopPropagation();
+                filterByAuthor(authorEl.dataset.author);
+                return;
             }
+
+            const card = e.target.closest('.character-card');
+            if (!card) return;
+            if (e.ctrlKey || e.metaKey || e.shiftKey || e.button !== 0) return;
+            e.preventDefault();
+            showCharacter(card.dataset.source, card.dataset.id);
+        });
+
+        modalContent.addEventListener('click', (e) => {
+            const authorEl = e.target.closest('.filter-author');
+            if (authorEl) {
+                e.preventDefault();
+                filterByAuthor(authorEl.dataset.author);
+                return;
+            }
+
+            const tagEl = e.target.closest('.filter-tag');
+            if (tagEl) {
+                if (e.ctrlKey || e.metaKey || e.shiftKey || e.button !== 0) return;
+                e.preventDefault();
+                filterByTag(tagEl.dataset.tag);
+                return;
+            }
+
+            const expandEl = e.target.closest('.tag-expand');
+            if (expandEl) {
+                e.preventDefault();
+                expandModalTags(expandEl);
+            }
+        });
+
+        if (BROWSE_ALL_ENABLED) {
+            stats.addEventListener('click', browseAllCharacters);
+        }
+
+        document.getElementById('sourceBrowse').addEventListener('click', (e) => {
+            const link = e.target.closest('.source-browse');
+            if (!link) return;
+            if (e.ctrlKey || e.metaKey || e.shiftKey || e.button !== 0) return;
+            e.preventDefault();
+            browseSource(link.dataset.source);
         });
 
         // Initialize
         loadStats();
-        searchInput.focus();
+        const restoredFromUrl = initFromUrl();
+        if (OPEN_CHARACTER) {
+            welcome.classList.add('hidden');
+            showCharacter(OPEN_CHARACTER.source, OPEN_CHARACTER.id);
+        } else if (!restoredFromUrl) {
+            nameFilter.focus();
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

This PR upgrades the Character Archive frontend and its deployment story: richer search and browsing in the UI, a PostgreSQL tag index for fast tag filters, and Docker Compose driven by a root `.env` instead of hardcoded secrets and IPs.

AI was used, but not blindly in creating this PR - I'm not a front-end dev. I'm DevOps.

### Frontend & API (`small_front/`)

- **Search & filters:** Name, author, and tag filters (required tags as comma-separated AND, exclusions with `-tag`), per-source filtering, sort by date added or name (asc/desc), and pagination.
- **Tag autocomplete:** New `/api/tags` endpoint backed by `tag_index` / `character_tags` tables (`sql/tag_index.sql`) with `rebuild_tag_index.py` and `rebuild_tags.example.sh` to populate and maintain the index.
- **UX:** Shareable URLs (filters in query string), `/character/<source>/<id>` deep links, click author/tag from cards or modal to filter, optional browse-all when `ENABLE_BROWSE_ALL` is set, archive stats on the home page.
- **Downloads:** PNG cards (existing) plus JSON export at `/api/card/<source>/<id>/json`.
- **Images:** Configurable `IMAGE_LAYOUT` (`flat` | `sharded`) and `IMAGE_SUBDIR` for archive paths; documented in `small_front/.env.example`.
- **Local dev:** `small_front/.env.example` and README updated to use `./runme.sh`.

### Docker & ops

- **Compose:** Credentials, bind host, ports, and image-path env vars come from root `.env.example` → `.env`.
- **Import flow:** `docker-compose.import.yml` is a merge overlay (init `database.dump` + `init-db.sh`) instead of a duplicated full stack.
- **Defaults:** Frontend uses sharded layout under `hashed-data/` when run via Compose.

### Docs & repo hygiene

- README feature list, image-storage section, project tree, and dev instructions updated.
- `docs/setup-guide.md`, `docs/MIGRATION.md`, and `docs/frontend-guide.md` aligned with the new Compose workflow.
- Root `.gitignore` added (secrets, `db_data/`, `archive/`, local scripts).

## Setup notes (reviewers / deployers)

1. Copy `.env.example` to `.env` at repo root and set passwords + `BIND_HOST`.
2. Apply tag index DDL and run `rebuild_tag_index.py` (or `rebuild_tags.sh` from the example script) before tag autocomplete and indexed tag filters perform well.
3. First-time DB import: `docker compose -f docker-compose.yml -f docker-compose.import.yml up -d`.

## Test plan

- [ ] `cp .env.example .env`, set credentials, `docker compose config` succeeds
- [ ] `docker compose up -d` - postgres, pgadmin, and frontend healthy; images load from `archive/hashed-data/` with default sharded env
- [ ] Search by name, author, and tags; verify `-tag` exclusion and multi-tag AND behavior
- [ ] Tag input shows autocomplete after index is built; empty index shows expected warning
- [ ] Sort (name/added, asc/desc) and pagination; URL reflects filters and reload restores state
- [ ] Open `/character/<source>/<id>` - modal loads correct card
- [ ] Download PNG and JSON from character modal
- [ ] Click author/tag in grid or modal - filters apply and search runs
- [ ] `GET /api/stats` and home-page stats match expectations
- [ ] Optional: `ENABLE_BROWSE_ALL=true` - browse-all works and is disabled when false - this is a slow call when enabled, so don't use unless you have the resources
- [ ] Local: `cd small_front && cp .env.example .env && ./runme.sh` - app starts and connects to DB
- [ ] Fresh import path: merge compose import overlay on empty `db_data/postgres`, confirm restore completes
